### PR TITLE
fix Chromeで新レンダラーが初期化に失敗する問題を修正

### DIFF
--- a/src/entrypoints/script_play.content/renderer/pixi.ts
+++ b/src/entrypoints/script_play.content/renderer/pixi.ts
@@ -1,3 +1,4 @@
+import 'pixi.js/unsafe-eval';
 import { Container, type RenderTexture, type TextStyle } from 'pixi.js';
 import { getConfig, watchConfig } from '@/config/storage';
 import type { Result } from '@/lib/types';


### PR DESCRIPTION
fix #134  

問題についてはissueに記載。
Pixiの初期化に失敗しているのでそれを修正、という方針で修正しました。
Pixiの初期化の処理よりupdateWorkInfoを先に実行することでも解消しましたが、新レンダラーが実装途中, 利用がオプショナルであることから将来的に解消される問題かと思い、一旦この対策で対応しました。
