### PR TITLE
[fix] 戻る/進む(popstate)時に視聴ページをリロードして動画をURLに一致させる

### DIFF
--- a/src/entrypoints/script_addons.content/history_navigation.ts
+++ b/src/entrypoints/script_addons.content/history_navigation.ts
@@ -1,0 +1,18 @@
+import type { ContentScriptContext } from 'wxt/utils/content-script-context';
+
+/**
+ * Dアニメは通常タブでの視聴時、ブラウザの戻る/進む(popstate)で動画プレイヤーを
+ * URLに追従させないため、動画とコメント・タイトルがズレる。
+ * 視聴ページで履歴移動を検知したらページをリロードし、再生中の動画をURLに一致させる。
+ *
+ * 話数切替はdアニメ内部ではpushStateで行われ popstate は発火しないため通常操作には
+ * 干渉せず、reload は popstate を発火させないため無限ループにもならない。
+ * popstate は戻る/進むが存在する環境でしか飛ばないため常時有効で安全。
+ */
+export const reload_on_history_navigation = (ctx: ContentScriptContext): void => {
+  ctx.addEventListener(window, 'popstate', () => {
+    if (window.location.href.includes('/animestore/sc_d_pc?partId=')) {
+      window.location.reload();
+    }
+  });
+};

--- a/src/entrypoints/script_addons.content/index.ts
+++ b/src/entrypoints/script_addons.content/index.ts
@@ -1,13 +1,17 @@
 import { getConfig } from '@/config/storage';
 import { addon_disable_new_window } from './disable_new_window';
+import { reload_on_history_navigation } from './history_navigation';
 import { add_button_to_play } from './work_page';
 
 export default defineContentScript({
-  async main() {
+  async main(ctx) {
     const path = window.location.pathname;
     if (path.includes('/animestore/ci_pc')) {
       if (await getConfig('enable_addon_add_button_to_play')) await add_button_to_play();
       if (await getConfig('enable_addon_disable_new_window')) await addon_disable_new_window();
+    }
+    if (path.includes('/animestore/sc_d_pc')) {
+      reload_on_history_navigation(ctx);
     }
   },
   matches: ['https://animestore.docomo.ne.jp/animestore/*'],


### PR DESCRIPTION
## 概要

dアニメは通常タブでの視聴時、ブラウザの戻る/進む(popstate)で動画プレイヤーをURLに追従させないため、動画とコメント・タイトルが違う話数を表示する不具合がある。
視聴ページで popstate を検知したらページをリロードし、再生中の動画をURLに一致させる。

## 備考

- 検証はChromeで行いました。
- 通常利用では戻るボタンはブラウザで表示されないのでほぼ問題になりませんが（それでもマウスボタンは機能する）、この拡張機能の『現在のタブで表示』によりユーザーにもブラウザの戻る進むボタンが露出するため、dアニメの実装不備が顕在化するかな、と思い実装しました。